### PR TITLE
Add a middleware to bypass Okta login requirement in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 config.yaml
 vendor
 store.bbolt
-rfd-server
-rfd-client

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/geekgonecrazy/rfd-tool/config"
 	"github.com/geekgonecrazy/rfd-tool/core"
@@ -48,6 +49,22 @@ func getSessionFromCookieOrHeader(c *gin.Context) {
 	if session.User.LoggedIn {
 		c.Set("loggedIn", true)
 		c.Set("userEmail", session.User.Email)
+	}
+
+	c.Next()
+}
+
+func _debugBypassEmptyLogin(c *gin.Context) {
+	if c.GetBool("loggedIn") {
+		c.Next()
+		return
+	}
+
+	bypassLogin := os.Getenv("RFD_BYPASS_EMPTY_LOGIN") == "true" && gin.IsDebugging()
+
+	if (bypassLogin) {
+		c.Set("loggedIn", true);
+		c.Set("userEmail", "dev@rfdtool.com")
 	}
 
 	c.Next()

--- a/router/router.go
+++ b/router/router.go
@@ -20,6 +20,7 @@ func Run() error {
 	router.GET("/oidc/callback", controllers.OIDCCallbackHandler)
 
 	router.Use(getSessionFromCookieOrHeader)
+	router.Use(_debugBypassEmptyLogin)
 
 	api := router.Group("/api/v1")
 	{


### PR DESCRIPTION
Hard requirement for Okta login for development makes it hard to get the project up and running quickly

Here I introduce a new env var `RFD_BYPASS_EMPTY_LOGIN` that causes the new middleware to inject fake login information in the current session. This only works if Gin is running in debug mode (`gin.IsDebugging()`)
