### PR TITLE
Be a bit more tolerant on branch name

### DIFF
--- a/cmd/rfd-client/main.go
+++ b/cmd/rfd-client/main.go
@@ -36,6 +36,8 @@ func main() {
 		panic("no valid RFD passed.  Use --rfd=rfdnumber")
 	}
 
+	rfdNum = r.FindString(rfdNum)
+
 	server = os.Getenv("RFD_SERVER")
 	token = os.Getenv("RFD_TOKEN")
 


### PR DESCRIPTION
extract the rfdNum from the matching text.

This should allow 0095-branch-name etc which people seem to want to do